### PR TITLE
upper bound the test dependency on DelDir to < 1.0.0

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 VoronoiDelaunay 0.1.0
-Deldir 0.0.3
+Deldir 0.0.3 1.0.0
 Compat 0.8.4
 BaseTestNext 0.2.2


### PR DESCRIPTION
since there was a breaking change there, ref https://github.com/JuliaLang/METADATA.jl/pull/10337#issuecomment-316892540
this is a quick fix to get `Pkg.test("VoronoiCells")` working again until this package can be made compatible

cc @robertdj 