### PR TITLE
Add RNG to make deterministic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ VoronoiDelaunay = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
 Deldir = "1.3"
 GeometryBasics = "0.4"
 RecipesBase = "1.2"
-VoronoiDelaunay = "0.4"
+VoronoiDelaunay = "0.4.4"
 julia = "^1.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.0"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 VoronoiDelaunay = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
 

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -30,7 +30,7 @@ function PointCollection(points, rect)
 end
 
 
-function raw_tesselation(pc::PointCollection; edges=nothing, rng = Xoshiro())
+function raw_tesselation(pc::PointCollection; edges=nothing, rng = MersenneTwister())
     n_points = length(pc.OriginalPoints)
 
     generators = VoronoiDelaunay.DelaunayTessellation2D{IndexablePoint2D}(n_points)
@@ -83,7 +83,7 @@ end
 Base.eltype(::Tessellation{T}) where T = T
 
 
-function voronoicells(pc::PointCollection{T}; edges=nothing, rng = Xoshiro()) where T
+function voronoicells(pc::PointCollection{T}; edges=nothing, rng = MersenneTwister()) where T
     rt = raw_tesselation(pc; edges, rng)
 
     computation_corners = corners(pc.ComputationRectangle)

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -34,7 +34,7 @@ function raw_tesselation(pc::PointCollection; edges=nothing, rng = Xoshiro())
     n_points = length(pc.OriginalPoints)
 
     generators = VoronoiDelaunay.DelaunayTessellation2D{IndexablePoint2D}(n_points)
-    # Note that the elements of pc.TransformedPoints are reordered by VoronoiDelaunay
+    # Note that, without a seeded RNG, the elements of pc.TransformedPoints are reordered by VoronoiDelaunay
     push!(generators, pc.TransformedPoints, rng)
 
     voronoi_cells = Dict(1:n_points .=> [Vector{VoronoiDelaunay.Point2D}(undef, 0) for _ in 1:n_points])
@@ -65,7 +65,7 @@ function raw_tesselation(pc::PointCollection; edges=nothing, rng = Xoshiro())
             if src > dst # order 
                 src,dst = dst,src
             end   
-            push!(edges, (src,dst), rng)
+            push!(edges, (src,dst))
         end
     end 
 

--- a/src/Cells.jl
+++ b/src/Cells.jl
@@ -30,12 +30,12 @@ function PointCollection(points, rect)
 end
 
 
-function raw_tesselation(pc::PointCollection; edges=nothing)
+function raw_tesselation(pc::PointCollection; edges=nothing, rng = Xoshiro())
     n_points = length(pc.OriginalPoints)
 
     generators = VoronoiDelaunay.DelaunayTessellation2D{IndexablePoint2D}(n_points)
     # Note that the elements of pc.TransformedPoints are reordered by VoronoiDelaunay
-    push!(generators, pc.TransformedPoints)
+    push!(generators, pc.TransformedPoints, rng)
 
     voronoi_cells = Dict(1:n_points .=> [Vector{VoronoiDelaunay.Point2D}(undef, 0) for _ in 1:n_points])
 
@@ -65,7 +65,7 @@ function raw_tesselation(pc::PointCollection; edges=nothing)
             if src > dst # order 
                 src,dst = dst,src
             end   
-            push!(edges, (src,dst))
+            push!(edges, (src,dst), rng)
         end
     end 
 
@@ -83,8 +83,8 @@ end
 Base.eltype(::Tessellation{T}) where T = T
 
 
-function voronoicells(pc::PointCollection{T}; edges=nothing) where T
-    rt = raw_tesselation(pc; edges)
+function voronoicells(pc::PointCollection{T}; edges=nothing, rng = Xoshiro()) where T
+    rt = raw_tesselation(pc; edges, rng)
 
     computation_corners = corners(pc.ComputationRectangle)
     for (corner_index, corner) in enumerate(computation_corners)

--- a/src/VoronoiCells.jl
+++ b/src/VoronoiCells.jl
@@ -3,7 +3,7 @@ module VoronoiCells
 import GeometryBasics
 import VoronoiDelaunay
 import VoronoiDelaunay: getx, gety
-import Random: Xoshiro
+import Random: MersenneTwister
 
 using RecipesBase
 

--- a/src/VoronoiCells.jl
+++ b/src/VoronoiCells.jl
@@ -3,6 +3,7 @@ module VoronoiCells
 import GeometryBasics
 import VoronoiDelaunay
 import VoronoiDelaunay: getx, gety
+import Random: Xoshiro
 
 using RecipesBase
 

--- a/test/Cells.jl
+++ b/test/Cells.jl
@@ -114,6 +114,28 @@ using Test
         @test (3,4) in edges
         @test (2,4) in edges 
         @test length(edges) == 5 
-    end 
+    end
+
+    @testset "Reproducibility" begin
+        rect = Rectangle(Point2(0, 0), Point2(1, 1))
+        rng = Xoshiro(1)
+        points = [Point2(rand(rng), rand(rng)) for _ in 1:10]
+        # without rng passed to voronoicells, cells won't be identical
+        cells1 = voronoicells(points, rect).Cells
+        cells2 = voronoicells(points, rect).Cells
+        same = true
+        for i in eachindex(cells1)
+            same = same && all(cells1[i] .== cells2[i])
+        end
+        @test !same
+        # with rng passed to voronoicells, cells will be identical
+        cells1 = voronoicells(points, rect, rng = Xoshiro(2)).Cells
+        cells2 = voronoicells(points, rect, rng = Xoshiro(2)).Cells
+        same = true
+        for i in eachindex(cells1)
+            same = same && all(cells1[i] .== cells2[i])
+        end
+        @test same
+    end
 end
 

--- a/test/Cells.jl
+++ b/test/Cells.jl
@@ -118,19 +118,20 @@ using Test
 
     @testset "Reproducibility" begin
         rect = Rectangle(Point2(0, 0), Point2(1, 1))
-        rng = Xoshiro(1)
+        rng = MersenneTwister(1337)
         points = [Point2(rand(rng), rand(rng)) for _ in 1:10]
-        # without rng passed to voronoicells, cells won't be identical
-        cells1 = voronoicells(points, rect).Cells
-        cells2 = voronoicells(points, rect).Cells
+        # with different rng passed to voronoicells, cells won't be identical
+        # therefore, without seeded RNG, usually also gives different answers
+        cells1 = voronoicells(points, rect, rng = MersenneTwister(2)).Cells
+        cells2 = voronoicells(points, rect, rng = MersenneTwister(3)).Cells
         same = true
         for i in eachindex(cells1)
             same = same && all(cells1[i] .== cells2[i])
         end
         @test !same
         # with rng passed to voronoicells, cells will be identical
-        cells1 = voronoicells(points, rect, rng = Xoshiro(2)).Cells
-        cells2 = voronoicells(points, rect, rng = Xoshiro(2)).Cells
+        cells1 = voronoicells(points, rect, rng = MersenneTwister(2)).Cells
+        cells2 = voronoicells(points, rect, rng = MersenneTwister(2)).Cells
         same = true
         for i in eachindex(cells1)
             same = same && all(cells1[i] .== cells2[i])


### PR DESCRIPTION
Solution to #34 

My [pull request to VoronoiDelauny ](https://github.com/JuliaGeometry/VoronoiDelaunay.jl/pull/65) was merged. My PR allows us to seed the call to `random!` that was causing the non-deterministic behavior, as the different orders of operations were leading to differences in the floating point answer. 

Here I have made an optional RNG argument to the call to `voronoicells`. My tests show that if you provide RNGs with different seeds, `voronoicells` gives two different answers, and that if we provide the same seed we get the same answer. 

This requirers VoronoiDelauny v0.4.4, which I changed in the `Project.toml`.